### PR TITLE
feat: improve aur-publish logging in non-GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          package: downgrade
+          version: 11.5.1-rc-aur.1
+          publish: false
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -1,0 +1,18 @@
+name: Restyled
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  restyled:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: restyled-io/actions/setup@v4
+      - uses: restyled-io/actions/run@v4
+        with:
+          suggestions: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+downgrade
 node_modules

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,0 +1,2 @@
+commit_template: |
+  chore(style): restyled by ${restyler.name}

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Environment:
   --env "SSH_PRIVATE_KEY=$(< ~/.ssh/aur)" \
   aur-publish \
   aur-publish downgrade \
-    --version "11.5.1_rc_aur.1" \
+    --version "11.5.1-rc-aur.1" \
     --git-email "$(git config get user.email)" \
     --git-username "$(git config get user.name)" \
     --no-publish

--- a/action.yml
+++ b/action.yml
@@ -13,19 +13,19 @@ inputs:
   release:
     description: |
       Updated `pkgrel` to set in the PKGBUILD
-    default: '1'
+    default: "1"
   git-email:
     description: |
       `git user.email` to set before comitting
-    default: '${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com'
+    default: "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
   git-username:
     description: |
       `git user.name` to set before committing
-    default: '${{ github.actor }}'
+    default: "${{ github.actor }}"
   publish:
     description: |
       Actually publish?
-    default: 'true'
+    default: "true"
 
 runs:
   using: docker

--- a/bin/aur-publish
+++ b/bin/aur-publish
@@ -40,13 +40,13 @@ EOM
 }
 
 if [[ "${GITHUB_ACTIONS:-false}" == 'true' ]]; then
-  group()    { echo "::group::$1"; }
+  group() { echo "::group::$1"; }
   endgroup() { echo "::endgroup::"; }
-  warning()  { echo "::warning title=$1::$2"; }
+  warning() { echo "::warning title=$1::$2"; }
 else
-  group()    { printf '\e[1m\e[34m::\e[0m \e[1m%s\e[0m\n' "$1"; }
+  group() { printf '\e[1m\e[34m::\e[0m \e[1m%s\e[0m\n' "$1"; }
   endgroup() { echo; }
-  warning()  { printf '\e[1;33mwarning\e[0m: \e[1m%s\e[0m. %s\n' "$1" "$2"; }
+  warning() { printf '\e[1;33mwarning\e[0m: \e[1m%s\e[0m. %s\n' "$1" "$2"; }
 fi
 
 pkgname=
@@ -86,7 +86,7 @@ while (($#)); do
     --no-publish)
       publish=0
       ;;
-    -h|--help)
+    -h | --help)
       usage
       exit 0
       ;;
@@ -150,7 +150,7 @@ if ((DOCKERIZED)); then
   cd "$HOME"
 
   group "Configuring SSH"
-  cat > ./.ssh/aur <<EOM
+  cat >./.ssh/aur <<EOM
 $SSH_PRIVATE_KEY
 EOM
 

--- a/bin/aur-publish
+++ b/bin/aur-publish
@@ -39,6 +39,16 @@ Environment:
 EOM
 }
 
+if [[ "${GITHUB_ACTIONS:-false}" == 'true' ]]; then
+  group()    { echo "::group::$1"; }
+  endgroup() { echo "::endgroup::"; }
+  warning()  { echo "::warning title=$1::$2"; }
+else
+  group()    { printf '\e[1m\e[34m::\e[0m \e[1m%s\e[0m\n' "$1"; }
+  endgroup() { echo; }
+  warning()  { printf '\e[1;33mwarning\e[0m: \e[1m%s\e[0m. %s\n' "$1" "$2"; }
+fi
+
 pkgname=
 pkgver=
 pkgrel=1
@@ -113,7 +123,7 @@ if ((DOCKERIZED)) && [[ -z "${SSH_PRIVATE_KEY:-}" ]]; then
   exit 1
 fi
 
-echo "::group::Publish information"
+group "Publish information"
 printf '\e[32mgit config\e[0m:\n'
 printf '  \e[35muser.email\e[0m: \e[34m%s\e[0m\n' "${git_email:-default}"
 printf '  \e[35muser.name\e[0m:  \e[34m%s\e[0m\n' "${git_username:-default}"
@@ -132,35 +142,35 @@ if ((!DOCKERIZED)); then
   printf '\e[1mNOTE\e[0m: running outside docker, SSH will not be configured.\n'
 fi
 
-echo "::endgroup::"
+endgroup
 
 if ((DOCKERIZED)); then
   # Fix GHA $HOME and WORKDIR, if necessary
   export HOME=/home/app
   cd "$HOME"
 
-  echo "::group::Configuring SSH"
+  group "Configuring SSH"
   cat > ./.ssh/aur <<EOM
 $SSH_PRIVATE_KEY
 EOM
 
   chmod 600 ./.ssh/aur
-  echo "::endgroup::"
+  endgroup
 fi
 
-echo "::group::Cloning repository"
+group "Cloning repository"
 git -c init.defaultBranch=master clone "ssh://aur@aur.archlinux.org/$pkgname.git" "$pkgname"
 cd "$pkgname"
-echo "::endgroup::"
+endgroup
 
-echo "::group::Update PKGBUILD and .SRCINFO"
+group "Update PKGBUILD and .SRCINFO"
 sed -i 's/^pkgver=.*$/pkgver='"$pkgver/" PKGBUILD
 sed -i 's/^pkgrel=.*$/pkgrel='"$pkgrel/" PKGBUILD
 updpkgsums
 makepkg --printsrcinfo >.SRCINFO
-echo "::endgroup::"
+endgroup
 
-echo "::group::Commit"
+group "Commit"
 if [[ -n "$git_email" ]]; then
   git config --global user.email "$git_email"
 fi
@@ -172,16 +182,16 @@ fi
 git add PKGBUILD .SRCINFO
 git --no-pager diff --cached --color=always
 git commit -m "Release $pkgver"
-echo "::endgroup::"
+endgroup
 
-echo "::group::Test install"
+group "Test install"
 makepkg --syncdeps --install --force --noconfirm
-echo "::endgroup::"
+endgroup
 
-echo "::group::Push"
+group "Push"
 if ((publish)); then
   git push
 else
-  echo "::warning title=Not pushing::The \`--no-publish\` flag was used"
+  warning "Not pushing" "The \`--no-publish\` flag was used"
 fi
-echo "::endgroup::"
+endgroup

--- a/test/run
+++ b/test/run
@@ -17,9 +17,9 @@ set -euo pipefail
 
 docker build --tag archlinux-downgrade/aur-publish-action:testing .
 docker run -it --rm \
-  --env "SSH_PRIVATE_KEY=$(< ~/.ssh/aur)" \
+  --env "SSH_PRIVATE_KEY=$(<~/.ssh/aur)" \
   archlinux-downgrade/aur-publish-action:testing aur-publish downgrade \
-      --version "11.5.1-rc-aur.1" \
-      --git-email "$(git config get user.email)" \
-      --git-username "$(git config get user.name)" \
-      --no-publish
+  --version "11.5.1-rc-aur.1" \
+  --git-email "$(git config get user.email)" \
+  --git-username "$(git config get user.name)" \
+  --no-publish

--- a/test/run
+++ b/test/run
@@ -19,7 +19,7 @@ docker build --tag archlinux-downgrade/aur-publish-action:testing .
 docker run -it --rm \
   --env "SSH_PRIVATE_KEY=$(< ~/.ssh/aur)" \
   archlinux-downgrade/aur-publish-action:testing aur-publish downgrade \
-      --version "11.5.1_rc_aur.1" \
+      --version "11.5.1-rc-aur.1" \
       --git-email "$(git config get user.email)" \
       --git-username "$(git config get user.name)" \
       --no-publish


### PR DESCRIPTION
Use `$GITHUB_ACTIONS` to know if we're on GHA. If not, use normal output
and not the `::`-commands.

As part of this, add CI and fixup some docs.